### PR TITLE
Add server (backend) connection metrics

### DIFF
--- a/proxysql.py
+++ b/proxysql.py
@@ -42,6 +42,9 @@ PROXYSQL_STATUS_VARS = {
     'Client_Connections_connected': 'gauge',
     'Client_Connections_created': 'counter',
     'Client_Connections_non_idle': 'gauge',
+    'Server_Connections_aborted': 'counter',
+    'Server_Connections_connected': 'gauge',
+    'Server_Connections_created': 'counter'
     'ProxySQL_Uptime': 'counter',
     'Questions': 'counter',
     'Slow_queries': 'counter',


### PR DESCRIPTION
As documented in ProxySQL docs:
https://github.com/sysown/proxysql/wiki/STATS-(statistics)#stats_mysql_global